### PR TITLE
clone / commit / push to maintain repo content when deploying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,26 +51,22 @@ jobs:
           mkdir ./input-cache
           curl -sS -L https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar -o ./input-cache/publisher.jar
           chmod +x ./input-cache/publisher.jar
-    # Download the IG Publisher
+
       - name: "Create IG"
         shell: bash
         run: |
           java -jar -Xms4096M -Xmx6144M -XX:NewRatio=1 -XX:-UseAdaptiveSizePolicy input-cache/publisher.jar ig.ini
-          mkdir -p ./git-output/vbai-fhir
-          cp -r ./output/* ./git-output/vbai-fhir 
-          echo "Kind Lab GitHub Pages for external webpages." > ./git-output/README.md
-      
 
-      
-      # Deploy IG
-      - name: Deploy to external repository
-        uses: cpina/github-action-push-to-another-repository@main
-        env: 
-          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
-        with:
-          source-directory: 'git-output'
-          destination-github-username: 'kind-lab'
-          destination-repository-name: 'kind-lab.github.io'
-       
-          
+      - name: "Deploy to kind-lab.github.io"
+        run: |
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git config --global user.name "github-actions[bot]"
+            git config --global credential.helper cache
+            git clone --depth 1 https://${{ secrets.GH_VBAI_PAT }}@github.com/kind-lab/kind-lab.github.io website
+            cd website
+            git rm -r vbai-fhir
+            mv ../output website/vbai-fhir
+            git add vbai-fhir
+            git commit -a -m "$(date): update vbai-fhir"
+            git push
      


### PR DESCRIPTION
Since we will have more than one website on kind-lab.github.io, it makes sense to clone / commit / push, rather than overwrite the entire repo, which is what I think the prior method would do

I haven't tested this though, it may run into access issues, but I think the token is configured correctly