### PR TITLE
Updated depoly on closing of pull request instead upon release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Build the IG
 on:
-  release:
-    types: [published]
+  pull_request:
+    types: [closed]
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Since we now commit the newly generated files into the main branch during the actions workflow, releases will always be 1 commit behind unless we deploy upon a pull request being merge/close.  
- Ensures that future releases are up to date.